### PR TITLE
copy/paste error

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -25,10 +25,10 @@ You will need to edit your hiera.yaml config file to include a foreman url, as w
     :yaml:
       :datadir: '/etc/puppet/hieradata'
     
-    :foreman:
-      :url: 'http://foreman.cas.unt.edu'
-      :user: 'USERNAME'
-      :pass: 'PASSWORD'
+    :foreman
+      :url 'http://foreman.cas.unt.edu'
+      :user 'USERNAME'
+      :pass 'PASSWORD'
 
 Contributors
 ------------


### PR DESCRIPTION
The foreman backend isn't looking for $data[":foreman:"] - it's actually using $data[":foreman"] <-  without the trailing :

I'm updating the docs to match for people who are like me and want to copy/paste...
