### PR TITLE
added keys/whitelist feature to reduce number of lookups

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -9,7 +9,7 @@ Since foreman has its own configurable search hierarchy, hiera-foreman does not 
 
 Configuration
 -------
-You will need to edit your hiera.yaml config file to include a foreman url, as well as a username, and password, if you're using HTTP Basic Auth. 
+You will need to edit your hiera.yaml config file to include a foreman url, as well as a username, and password, if you're using HTTP Basic Auth. Keys is an optional whitelist. If it is defined then any lookup key must be listed. If it is not listed nil is returned. This allows for strict control over what can be set per host in Foreman and also speeds up catalogue compilation.
 
     ---
     :backends:
@@ -29,6 +29,12 @@ You will need to edit your hiera.yaml config file to include a foreman url, as w
       :url: 'http://foreman.cas.unt.edu'
       :user: 'USERNAME'
       :pass: 'PASSWORD'
+      :keys:
+        - classes
+        - foreman_env
+        - puppetmaster
+        - location
+        - patchrelease
 
 Contributors
 ------------

--- a/lib/hiera/backend/foreman_backend.rb
+++ b/lib/hiera/backend/foreman_backend.rb
@@ -18,6 +18,7 @@ class Hiera
         @url  = Config[:foreman][:url]
         @user = Config[:foreman][:user]
         @pass = Config[:foreman][:pass]
+        @keys = Config[:foreman][:keys]
       end
 
       def lookup(key, scope, order_override, resolution_type)
@@ -54,6 +55,10 @@ class Hiera
 
       def lookup_enc(fqdn, key)
         Hiera.debug("Performing Foreman ENC lookup on #{fqdn} for #{key}")
+        if (defined?(@keys) and @keys.is_a?(Array) and @keys.size > 0 )  and not @keys.include?(key)
+          Hiera.debug("Skipping, #{key} not found in #{@keys.inspect}")
+          return nil
+        end
 
         path = URI.parse("#{@url}/node/#{fqdn}?format=yml")
         req  = Net::HTTP::Get.new(path.request_uri)


### PR DESCRIPTION
Hi,

to reduce the number of Foreman lookups we use a whitelist. This reduced catalogue compile time from 62 to 12 seconds and also allows for control over what can be set in foreman.

Thanks,
Frank
